### PR TITLE
FAI-806: Added distutils workaround to sitepackages virtualenv bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 from setuptools import setup
 from setuptools.command.install import install
+from distutils.sysconfig import get_python_lib
 import site
 
 here = os.path.abspath(os.path.dirname(__file__))
@@ -18,7 +19,6 @@ class PostInstall(install):
         try:
             _ROOT = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
         except AttributeError:
-            from distutils.sysconfig import get_python_lib
             _ROOT = os.path.join(get_python_lib(), "trustyai", "dep")
         print(f"Installing Maven dependencies into {_ROOT}")
         os.system(f"mvn org.apache.maven.plugins:maven-dependency-plugin:2.10:get "

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ class PostInstall(install):
 
     def run(self):
         install.run(self)
-        _ROOT = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+        try:
+            _ROOT = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+        except AttributeError:
+            from distutils.sysconfig import get_python_lib
+            _ROOT = os.path.join(get_python_lib(), "trustyai", "dep")
         print(f"Installing Maven dependencies into {_ROOT}")
         os.system(f"mvn org.apache.maven.plugins:maven-dependency-plugin:2.10:get "
                   f"-DremoteRepositories=https://repository.sonatype.org/content/repositories/central  "

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -13,7 +13,11 @@ import jpype.imports
 from jpype import _jcustomizer, _jclass
 
 TRUSTY_VERSION = "1.22.1.Final"
-DEFAULT_DEP_PATH = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+try:
+    DEFAULT_DEP_PATH = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
+except AttributeError:
+    from distutils.sysconfig import get_python_lib
+    DEFAULT_DEP_PATH = os.path.join(get_python_lib(), "trustyai", "dep")
 print(DEFAULT_DEP_PATH)
 
 CORE_DEPS = [

--- a/trustyai/__init__.py
+++ b/trustyai/__init__.py
@@ -7,16 +7,17 @@ from pathlib import Path
 from typing import List
 import glob
 import logging
+from distutils.sysconfig import get_python_lib
 
 import jpype
 import jpype.imports
 from jpype import _jcustomizer, _jclass
 
+
 TRUSTY_VERSION = "1.22.1.Final"
 try:
     DEFAULT_DEP_PATH = os.path.join(site.getsitepackages()[0], "trustyai", "dep")
 except AttributeError:
-    from distutils.sysconfig import get_python_lib
     DEFAULT_DEP_PATH = os.path.join(get_python_lib(), "trustyai", "dep")
 print(DEFAULT_DEP_PATH)
 


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-806

When trying to build the module in a virtualenv the site.getsitepackages() function can fail due to some strange virtualenv bug: https://github.com/pypa/virtualenv/issues/737, meaning ReadTheDocs can't build trustyai. This introduces a possible workaround using distutils.

