### PR TITLE
FAI-816: Fixed incorrect ShapResults.get_saliency output type

### DIFF
--- a/tests/general/test_shap.py
+++ b/tests/general/test_shap.py
@@ -28,7 +28,7 @@ def test_no_variance_one_output():
     explanations = [shap_explainer.explain(prediction, model) for prediction in predictions]
 
     for explanation in explanations:
-        for saliency in explanation.get_saliencies():
+        for output_name, saliency in explanation.get_saliencies().items():
             for feature_importance in saliency.getPerFeatureImportance():
                 assert feature_importance.getScore() == 0.0
 
@@ -48,7 +48,7 @@ def test_shap_arrow():
     explanation = shap_explainer.explain(prediction, model)
 
     answers = [-.152, -.114, 0.00304, .0525, -.0725]
-    for saliency in explanation.get_saliencies():
+    for output_name, saliency in explanation.get_saliencies().items():
         for i, feature_importance in enumerate(saliency.getPerFeatureImportance()):
             assert answers[i]-1e-2 <= feature_importance.getScore() <= answers[i]+1e-2
 

--- a/tests/general/test_shap.py
+++ b/tests/general/test_shap.py
@@ -1,4 +1,4 @@
-# pylint: disable=import-error, wrong-import-position, wrong-import-order, duplicate-code
+# pylint: disable=import-error, wrong-import-position, wrong-import-order, duplicate-code, unused-import
 """SHAP explainer test suite"""
 
 from common import *
@@ -28,7 +28,7 @@ def test_no_variance_one_output():
     explanations = [shap_explainer.explain(prediction, model) for prediction in predictions]
 
     for explanation in explanations:
-        for output_name, saliency in explanation.get_saliencies().items():
+        for _, saliency in explanation.get_saliencies().items():
             for feature_importance in saliency.getPerFeatureImportance():
                 assert feature_importance.getScore() == 0.0
 

--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -388,10 +388,11 @@ class SHAPResults(ExplanationVisualiser):
              A dictionary of :class:`~trustyai.model.Saliency` objects, keyed by output name.
         """
         saliencies = self.shap_results.getSaliencies()
-        if type(saliencies) is dict:
-            return saliencies
+        if isinstance(saliencies, dict):
+            output = saliencies
         else:
-            return {s.getOutput().getName(): s for s in saliencies}
+            output = {s.getOutput().getName(): s for s in saliencies}
+        return output
 
     def get_fnull(self):
         """
@@ -420,7 +421,7 @@ class SHAPResults(ExplanationVisualiser):
         """
 
         visualizer_data_frame = pd.DataFrame()
-        for i, (output_name, saliency) in enumerate(self.get_saliencies().items()):
+        for i, (_, saliency) in enumerate(self.get_saliencies().items()):
             background_mean_feature_values = np.mean(
                 [
                     [f.getValue().asNumber() for f in pi.getFeatures()]


### PR DESCRIPTION
[FAI-816](https://issues.redhat.com/browse/FAI-816)

Adds a a bandaid type check to ensure the regardless of the Java library version the Python bindings `ShapResults.get_saliencies()` always outputs a `Dict[output_name, Saliency]`