### PR TITLE
FAI-802: Removed unused perturbation argument from SHAP explainer

### DIFF
--- a/trustyai/explainers.py
+++ b/trustyai/explainers.py
@@ -678,7 +678,6 @@ class SHAPExplainer:
         samples=None,
         batch_size=20,
         seed=0,
-        perturbations=0,
         link_type: Optional[_ShapConfig.LinkType] = None,
     ):
         r"""Initialize the :class:`SHAPxplainer`.
@@ -700,8 +699,6 @@ class SHAPExplainer:
             performance gains.
         seed: int
             The random seed to be used when generating explanations.
-        perturbations: int
-            This argument has no effect and will be removed shortly, ignore.
         link_type : :obj:`~_ShapConfig.LinkType`
             A choice of either ``trustyai.explainers._ShapConfig.LinkType.IDENTITY``
             or ``trustyai.explainers._ShapConfig.LinkType.LOGIT``. If the model output is a
@@ -717,7 +714,7 @@ class SHAPExplainer:
             link_type = _ShapConfig.LinkType.IDENTITY
         self._jrandom = Random()
         self._jrandom.setSeed(seed)
-        perturbation_context = PerturbationContext(self._jrandom, perturbations)
+        perturbation_context = PerturbationContext(self._jrandom, 0)
 
         if isinstance(background, np.ndarray):
             self.background = Dataset.numpy_to_prediction_object(background, feature)


### PR DESCRIPTION
[FAI-802](https://issues.redhat.com/browse/FAI-802)

The SHAPExplainer had an unused "perturbation" argument, this is now removed.