### PR TITLE
FAI-845: Change PyPi upload endpoint from test to live

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,4 +19,3 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/


### PR DESCRIPTION
The PyPi upload endpoint can be changed from the test site (`test.pypi.org`) to the live one (`pypi.org`).