### PR TITLE
FAI-853: Python bindings for unified results

### DIFF
--- a/src/trustyai/explainers.py
+++ b/src/trustyai/explainers.py
@@ -188,13 +188,13 @@ class CounterfactualExplainer:
 
     # pylint: disable=too-many-arguments
     def explain(
-            self,
-            inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-            goal: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-            model: PredictionProvider,
-            data_distribution: Optional[DataDistribution] = None,
-            uuid: Optional[_uuid.UUID] = None,
-            timeout: Optional[float] = None,
+        self,
+        inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        goal: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        model: PredictionProvider,
+        data_distribution: Optional[DataDistribution] = None,
+        uuid: Optional[_uuid.UUID] = None,
+        timeout: Optional[float] = None,
     ) -> CounterfactualResult:
         """Request for a counterfactual explanation given a list of features, goals and a
         :class:`~PredictionProvider`
@@ -316,7 +316,7 @@ class LimeResults(ExplanationVisualiser):
         with mpl.rc_context(drcp):
             dictionary = {}
             for feature_importance in self._saliencies.saliencies.get(
-                    decision
+                decision
             ).getPerFeatureImportance():
                 dictionary[
                     feature_importance.getFeature().name
@@ -350,12 +350,12 @@ class LimeExplainer:
     """
 
     def __init__(
-            self,
-            perturbations=1,
-            seed=0,
-            samples=10,
-            penalise_sparse_balance=True,
-            normalise_weights=True,
+        self,
+        perturbations=1,
+        seed=0,
+        samples=10,
+        penalise_sparse_balance=True,
+        normalise_weights=True,
     ):
         """Initialize the :class:`LimeExplainer`.
 
@@ -390,10 +390,10 @@ class LimeExplainer:
         self._explainer = _LimeExplainer(self._lime_config)
 
     def explain(
-            self,
-            inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-            outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-            model: PredictionProvider,
+        self,
+        inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        model: PredictionProvider,
     ) -> LimeResults:
         """Produce a LIME explanation.
 
@@ -697,12 +697,12 @@ class SHAPExplainer:
     """
 
     def __init__(
-            self,
-            background: Union[np.ndarray, pd.DataFrame, List[PredictionInput]],
-            samples=None,
-            batch_size=20,
-            seed=0,
-            link_type: Optional[_ShapConfig.LinkType] = None,
+        self,
+        background: Union[np.ndarray, pd.DataFrame, List[PredictionInput]],
+        samples=None,
+        batch_size=20,
+        seed=0,
+        link_type: Optional[_ShapConfig.LinkType] = None,
     ):
         r"""Initialize the :class:`SHAPxplainer`.
 
@@ -764,10 +764,10 @@ class SHAPExplainer:
         self._explainer = _ShapKernelExplainer(self._config)
 
     def explain(
-            self,
-            inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-            outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-            model: PredictionProvider,
+        self,
+        inputs: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        model: PredictionProvider,
     ) -> SHAPResults:
         """Produce a SHAP explanation.
 

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -29,6 +29,7 @@ from org.kie.trustyai.explainability.model import (
     PredictionOutput as _PredictionOutput,
     Prediction as _Prediction,
     Saliency as _Saliency,
+    SaliencyResults as _SaliencyResults,
     SimplePrediction as _SimplePrediction,
     Value as _Value,
     Type as _Type,
@@ -141,7 +142,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-        df: pd.DataFrame, func
+            df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -175,7 +176,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-        array: np.ndarray, func, names=None
+            array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -219,7 +220,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -248,7 +249,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -295,7 +296,7 @@ class PredictionProvider:
     """
 
     def __init__(
-        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -421,7 +422,7 @@ class Model:
     """
 
     def __init__(
-        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -739,6 +740,19 @@ class _JPredictionFeatureDomain:
         return self.getFeatureDomains()
 
 
+@_jcustomizer.JImplementationFor(
+    "org.kie.trustyai.explainability.model.SaliencyResults"
+)
+# pylint: disable=no-member
+class SaliencyResults:
+    """Java PredictionFeatureDomain implicit methods"""
+
+    @property
+    def saliencies(self):
+        """Return saliencies"""
+        return self.getSaliencies()
+
+
 def output(name, dtype, value=None, score=1.0) -> _Output:
     """Create a Java :class:`Output`. The :class:`Output` class is used to represent the
     individual components of model outputs.
@@ -834,8 +848,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -889,11 +903,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-    data_distribution: Optional[DataDistribution] = None,
-    uuid: Optional[_uuid.UUID] = None,
-    timeout: Optional[float] = None,
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        data_distribution: Optional[DataDistribution] = None,
+        uuid: Optional[_uuid.UUID] = None,
+        timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -142,7 +142,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-            df: pd.DataFrame, func
+        df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -176,7 +176,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-            array: np.ndarray, func, names=None
+        array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -220,7 +220,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -249,7 +249,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -296,7 +296,7 @@ class PredictionProvider:
     """
 
     def __init__(
-            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -422,7 +422,7 @@ class Model:
     """
 
     def __init__(
-            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -752,6 +752,14 @@ class SaliencyResults:
         """Return saliencies"""
         return self.getSaliencies()
 
+    def __sub__(self, other: _SaliencyResults):
+        """Overload SaliencyResults difference"""
+        return self.difference(other)
+
+    def __eq__(self, other: _SaliencyResults):
+        """Overload SaliencyResults equality"""
+        return self.equals(other)
+
 
 def output(name, dtype, value=None, score=1.0) -> _Output:
     """Create a Java :class:`Output`. The :class:`Output` class is used to represent the
@@ -848,8 +856,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -903,11 +911,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-        data_distribution: Optional[DataDistribution] = None,
-        uuid: Optional[_uuid.UUID] = None,
-        timeout: Optional[float] = None,
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    data_distribution: Optional[DataDistribution] = None,
+    uuid: Optional[_uuid.UUID] = None,
+    timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the


### PR DESCRIPTION
Python bindings counterparts for the `SaliencyResults` unification of https://github.com/trustyai-explainability/trustyai-explainability/pull/28