### PR TITLE
FAI-852: Fix Python conversion for categorical features with integer backing

### DIFF
--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -1,4 +1,4 @@
-# pylint: disable = import-error, too-few-public-methods, invalid-name, duplicate-code,
+# pylint: disable = import-error, too-few-public-methods, invalid-name, duplicate-code, too-many-lines
 # pylint: disable = unused-import, wrong-import-order
 """General model classes"""
 import uuid as _uuid
@@ -152,7 +152,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-        df: pd.DataFrame, func
+            df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -186,7 +186,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-        array: np.ndarray, func, names=None
+            array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -230,7 +230,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -259,7 +259,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -306,7 +306,7 @@ class PredictionProvider:
     """
 
     def __init__(
-        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -432,7 +432,7 @@ class Model:
     """
 
     def __init__(
-        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -872,8 +872,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -927,11 +927,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-    data_distribution: Optional[DataDistribution] = None,
-    uuid: Optional[_uuid.UUID] = None,
-    timeout: Optional[float] = None,
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        data_distribution: Optional[DataDistribution] = None,
+        uuid: Optional[_uuid.UUID] = None,
+        timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -152,7 +152,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-            df: pd.DataFrame, func
+        df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -186,7 +186,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-            array: np.ndarray, func, names=None
+        array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -230,7 +230,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -259,7 +259,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -306,7 +306,7 @@ class PredictionProvider:
     """
 
     def __init__(
-            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -432,7 +432,7 @@ class Model:
     """
 
     def __init__(
-            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -872,8 +872,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -927,11 +927,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-        data_distribution: Optional[DataDistribution] = None,
-        uuid: Optional[_uuid.UUID] = None,
-        timeout: Optional[float] = None,
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    data_distribution: Optional[DataDistribution] = None,
+    uuid: Optional[_uuid.UUID] = None,
+    timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -13,7 +13,17 @@ from trustyai.utils import JImplementsWithDocstring
 
 from java.lang import Long
 from java.util.concurrent import CompletableFuture
-from jpype import JImplements, JOverride, _jcustomizer, _jclass, JByte, JArray, JLong, JInt, JString
+from jpype import (
+    JImplements,
+    JOverride,
+    _jcustomizer,
+    _jclass,
+    JByte,
+    JArray,
+    JLong,
+    JInt,
+    JString,
+)
 from org.kie.trustyai.explainability.local.counterfactual.entities import (
     CounterfactualEntity,
 )
@@ -142,7 +152,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-            df: pd.DataFrame, func
+        df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -176,7 +186,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-            array: np.ndarray, func, names=None
+        array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -220,7 +230,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -249,7 +259,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-            objects: Union[List[PredictionInput], List[PredictionOutput]]
+        objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -296,7 +306,7 @@ class PredictionProvider:
     """
 
     def __init__(
-            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -422,7 +432,7 @@ class Model:
     """
 
     def __init__(
-            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -862,8 +872,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -917,11 +927,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-        data_distribution: Optional[DataDistribution] = None,
-        uuid: Optional[_uuid.UUID] = None,
-        timeout: Optional[float] = None,
+    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+    data_distribution: Optional[DataDistribution] = None,
+    uuid: Optional[_uuid.UUID] = None,
+    timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -13,7 +13,7 @@ from trustyai.utils import JImplementsWithDocstring
 
 from java.lang import Long
 from java.util.concurrent import CompletableFuture
-from jpype import JImplements, JOverride, _jcustomizer, _jclass, JByte, JArray, JLong
+from jpype import JImplements, JOverride, _jcustomizer, _jclass, JByte, JArray, JLong, JInt, JString
 from org.kie.trustyai.explainability.local.counterfactual.entities import (
     CounterfactualEntity,
 )
@@ -141,7 +141,7 @@ class Dataset:
     # pylint: disable=comparison-with-callable
     @staticmethod
     def df_to_prediction_object(
-        df: pd.DataFrame, func
+            df: pd.DataFrame, func
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Pandas DataFrame into a list of TrustyAI
@@ -175,7 +175,7 @@ class Dataset:
 
     @staticmethod
     def numpy_to_prediction_object(
-        array: np.ndarray, func, names=None
+            array: np.ndarray, func, names=None
     ) -> Union[List[PredictionInput], List[PredictionOutput]]:
         """
         Convert a Numpy array into a list of TrustyAI
@@ -219,7 +219,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_numpy(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> np.array:
         """
         Convert a list of TrustyAI
@@ -248,7 +248,7 @@ class Dataset:
 
     @staticmethod
     def prediction_object_to_pandas(
-        objects: Union[List[PredictionInput], List[PredictionOutput]]
+            objects: Union[List[PredictionInput], List[PredictionOutput]]
     ) -> pd.DataFrame:
         """
         Convert a list of TrustyAI
@@ -295,7 +295,7 @@ class PredictionProvider:
     """
 
     def __init__(
-        self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
+            self, predict_fun: Callable[[List[PredictionInput]], List[PredictionOutput]]
     ):
         """
         Create the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -421,7 +421,7 @@ class Model:
     """
 
     def __init__(
-        self, predict_fun, dataframe_input=False, output_names=None, arrow=False
+            self, predict_fun, dataframe_input=False, output_names=None, arrow=False
     ):
         """
         Wrap the model as a TrustyAI :obj:`PredictionProvider` Java class.
@@ -817,7 +817,12 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
     """
 
     if dtype == "categorical":
-        _factory = FeatureFactory.newCategoricalFeature
+        if isinstance(value, int):
+            _factory = FeatureFactory.newCategoricalNumericalFeature
+            value = JInt(value)
+        else:
+            _factory = FeatureFactory.newCategoricalFeature
+            value = JString(value)
     elif dtype == "number":
         _factory = FeatureFactory.newNumericalFeature
     elif dtype == "bool":
@@ -825,6 +830,7 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
     else:
         _factory = FeatureFactory.newObjectFeature
 
+    name = JString(name)
     if domain:
         _feature = _factory(name, value, feature_domain(domain))
     else:
@@ -834,8 +840,8 @@ def feature(name: str, dtype: str, value=None, domain=None) -> Feature:
 
 # pylint: disable=line-too-long
 def simple_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
 ) -> SimplePrediction:
     """Wrap features and outputs into a SimplePrediction. Given a list of features and outputs,
     this function will bundle them into Prediction objects for use with the LIME and SHAP
@@ -889,11 +895,11 @@ def simple_prediction(
 
 # pylint: disable=too-many-arguments
 def counterfactual_prediction(
-    input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
-    outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
-    data_distribution: Optional[DataDistribution] = None,
-    uuid: Optional[_uuid.UUID] = None,
-    timeout: Optional[float] = None,
+        input_features: Union[np.ndarray, pd.DataFrame, List[Feature], PredictionInput],
+        outputs: Union[np.ndarray, pd.DataFrame, List[Output], PredictionOutput],
+        data_distribution: Optional[DataDistribution] = None,
+        uuid: Optional[_uuid.UUID] = None,
+        timeout: Optional[float] = None,
 ) -> CounterfactualPrediction:
     """Wrap features and outputs into a CounterfactualPrediction. Given a list of features and
     outputs, this function will bundle them into Prediction objects for use with the

--- a/tests/general/test_conversions.py
+++ b/tests/general/test_conversions.py
@@ -73,6 +73,11 @@ def test_feature_function():
     assert f3.value.as_string() == "foo"
     assert f3.type == Type.CATEGORICAL
 
+    f4 = feature(name="f-4", value=5, dtype="categorical")
+    assert f4.name == "f-4"
+    assert f4.value.as_number() == 5
+    assert f4.type == Type.CATEGORICAL
+
 
 def test_feature_domains():
     """Test domains"""


### PR DESCRIPTION
Creating categorical features with a string backing works as expected, but not with integer backings.
This causes errors when using transformers (e.g. `OrdinalEncoders`).