### PR TITLE
[FAI-860] Improve CI: enable test for Arrow module + make Expl-core build more reliable + minor improvements

### DIFF
--- a/.github/actions/build-arrow-converter/action.yml
+++ b/.github/actions/build-arrow-converter/action.yml
@@ -1,9 +1,10 @@
 name: Build arrow-converter JAR
+description: Build TrustyAI - Apache Arrow converter
 runs:
   using: "composite"
   steps:
     - name: Build arrow-converter
       shell: bash
       run: |
-        mvn compile package -DskipTests -f java_sources/trusty-ai-arrow/pom.xml
+        mvn clean package -f java_sources/trusty-ai-arrow/pom.xml -fae -e -nsu
         mv java_sources/trusty-ai-arrow/target/arrow-converters-*.jar src/trustyai/dep/org/trustyai/

--- a/.github/actions/build-core/action.yml
+++ b/.github/actions/build-core/action.yml
@@ -1,4 +1,5 @@
 name: Build exp-core JAR
+description: Clone and build TrustyAI-Explainability library (shaded in a single JAR)
 runs:
   using: "composite"
   steps:
@@ -6,6 +7,6 @@ runs:
       shell: bash
       run: |
         git clone https://github.com/trustyai-explainability/trustyai-explainability.git
-        mvn install package -DskipTests -f trustyai-explainability/explainability-core/pom.xml -Pshaded
+        mvn clean package -DskipTests -f trustyai-explainability/pom.xml -Pshaded -fae -e -nsu
         mv trustyai-explainability/explainability-core/target/explainability-core-*-SNAPSHOT.jar src/trustyai/dep/org/trustyai/
         

--- a/.github/actions/build-core/action.yml
+++ b/.github/actions/build-core/action.yml
@@ -7,6 +7,6 @@ runs:
       shell: bash
       run: |
         git clone https://github.com/trustyai-explainability/trustyai-explainability.git
-        mvn clean package -DskipTests -f trustyai-explainability/pom.xml -Pshaded -fae -e -nsu
+        mvn clean install -DskipTests -f trustyai-explainability/pom.xml -Pshaded -fae -e -nsu
         mv trustyai-explainability/explainability-core/target/explainability-core-*-SNAPSHOT.jar src/trustyai/dep/org/trustyai/
         

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,17 +8,15 @@ jobs:
     strategy:
       matrix:
         python-version: [ 3.7, 3.8, 3.9 ]
-
+        java-version: [ 11 ]
+        maven-version: [ '3.8.6' ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - name: Set up JDK + Maven version
+        uses: s4u/setup-maven-action@v1.4.0
         with:
-          distribution: "adopt"
-          java-version: "11"
-          check-latest: true
-      - uses: stCarolas/setup-maven@v4
-        with:
-          maven-version: 3.8.6
+          java-version: ${{ matrix.java-version }}
+          maven-version: ${{ matrix.maven-version }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
https://issues.redhat.com/browse/FAI-860

This PR improves CI:
- Tests of `trusty-ai-arrow` were disabled
- Shade jar for python binding was not building `trustyai-explainability` root modules (so it was just fetching that file from maven repositories)
- Minor improvement in Java/Maven version configuration