### PR TITLE
set normalize_weights to False in LimeExplainer as in Java impl

### DIFF
--- a/src/trustyai/explainers.py
+++ b/src/trustyai/explainers.py
@@ -355,7 +355,7 @@ class LimeExplainer:
         seed=0,
         samples=10,
         penalise_sparse_balance=True,
-        normalise_weights=True,
+        normalise_weights=False,
     ):
         """Initialize the :class:`LimeExplainer`.
 


### PR DESCRIPTION
`normalize_weights` param of `LimeExplainer` should be set to `False` as in the java implementation.