### PR TITLE
FAI-825: Add feature and output name specification to models

### DIFF
--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -224,9 +224,15 @@ class CounterfactualExplainer:
         :class:`~CounterfactualResult`
             Object containing the results of the counterfactual explanation.
         """
+        feature_names = model.feature_names if isinstance(model, Model) else None
+        output_names = model.output_names if isinstance(model, Model) else None
         _prediction = counterfactual_prediction(
-            input_features=one_input_convert(inputs, feature_domains=feature_domains),
+            input_features=one_input_convert(
+                inputs, feature_names=feature_names, feature_domains=feature_domains
+            ),
             outputs=goal,
+            feature_names=feature_names,
+            output_names=output_names,
             data_distribution=data_distribution,
             uuid=uuid,
             timeout=timeout,

--- a/src/trustyai/explainers/lime.py
+++ b/src/trustyai/explainers/lime.py
@@ -153,7 +153,7 @@ class LimeResults(SaliencyResults):
                 else ds["positive_primary_colour"]
                 for i in dictionary.values()
             ]
-            plt.title(f"LIME explanation of {output_name}")
+            plt.title(f"LIME: Feature Importances to {output_name}")
             plt.barh(
                 range(len(dictionary)),
                 dictionary.values(),
@@ -306,7 +306,9 @@ class LimeExplainer:
         :class:`~LimeResults`
             Object containing the results of the LIME explanation.
         """
-        _prediction = simple_prediction(inputs, outputs)
+        feature_names = model.feature_names if isinstance(model, Model) else None
+        output_names = model.output_names if isinstance(model, Model) else None
+        _prediction = simple_prediction(inputs, outputs, feature_names, output_names)
 
         with Model.ArrowTransmission(model, inputs):
             return LimeResults(self._explainer.explainAsync(_prediction, model).get())

--- a/src/trustyai/utils/data_conversions.py
+++ b/src/trustyai/utils/data_conversions.py
@@ -6,7 +6,6 @@ from typing import Union, List, Optional
 from itertools import filterfalse
 
 import trustyai.model
-from trustyai.model.domain import feature_domain
 from org.kie.trustyai.explainability.model import (
     Dataframe,
     Feature,
@@ -184,21 +183,29 @@ def domain_insertion(
 
 # === input functions ==============================================================================
 def one_input_convert(
-    python_inputs: OneInputUnionType, feature_domains: FeatureDomain = None
+    python_inputs: OneInputUnionType,
+    feature_names: Optional[List[str]] = None,
+    feature_domains: Optional[List[FeatureDomain]] = None,
 ) -> PredictionInput:
     """Convert an object of OneInputUnionType into a PredictionInput."""
     if isinstance(python_inputs, (int, float, np.number)):
         python_inputs = np.array([[python_inputs]])
-        pi = numpy_to_prediction_object(python_inputs, trustyai.model.feature)[0]
+        pi = numpy_to_prediction_object(
+            python_inputs, trustyai.model.feature, names=feature_names
+        )[0]
     elif isinstance(python_inputs, list) and all(
         (isinstance(x, (int, float, np.number)) for x in python_inputs)
     ):
         python_inputs = np.array(python_inputs).reshape(1, -1)
-        pi = numpy_to_prediction_object(python_inputs, trustyai.model.feature)[0]
+        pi = numpy_to_prediction_object(
+            python_inputs, trustyai.model.feature, names=feature_names
+        )[0]
     elif isinstance(python_inputs, np.ndarray):
         if len(python_inputs.shape) == 1:
             python_inputs = python_inputs.reshape(1, -1)
-        pi = numpy_to_prediction_object(python_inputs, trustyai.model.feature)[0]
+        pi = numpy_to_prediction_object(
+            python_inputs, trustyai.model.feature, names=feature_names
+        )[0]
     elif isinstance(python_inputs, pd.DataFrame):
         pi = df_to_prediction_object(python_inputs, trustyai.model.feature)[0]
     elif isinstance(python_inputs, pd.Series):
@@ -217,13 +224,17 @@ def one_input_convert(
 
 
 def many_inputs_convert(
-    python_inputs: ManyInputsUnionType, feature_domains: List[FeatureDomain] = None
+    python_inputs: ManyInputsUnionType,
+    feature_names: Optional[List[str]] = None,
+    feature_domains: Optional[List[FeatureDomain]] = None,
 ) -> List[PredictionInput]:
     """Convert an object of ManyInputsUnionType into a List[PredictionInput]"""
     if isinstance(python_inputs, np.ndarray):
         if len(python_inputs.shape) == 1:
             python_inputs = python_inputs.reshape(1, -1)
-        pis = numpy_to_prediction_object(python_inputs, trustyai.model.feature)
+        pis = numpy_to_prediction_object(
+            python_inputs, trustyai.model.feature, names=feature_names
+        )
     elif isinstance(python_inputs, pd.DataFrame):
         pis = df_to_prediction_object(python_inputs, trustyai.model.feature)
     else:
@@ -236,20 +247,28 @@ def many_inputs_convert(
 
 
 # === output functions =============================================================================
-def one_output_convert(python_outputs: OneOutputUnionType) -> PredictionOutput:
+def one_output_convert(
+    python_outputs: OneOutputUnionType, names: Optional[List[str]] = None
+) -> PredictionOutput:
     """Convert an object of OneOutputUnionType into a PredictionOutput"""
     if isinstance(python_outputs, (int, np.integer, float, np.inexact)):
         python_outputs = np.array([[python_outputs]])
-        po = numpy_to_prediction_object(python_outputs, trustyai.model.output)[0]
+        po = numpy_to_prediction_object(
+            python_outputs, trustyai.model.output, names=names
+        )[0]
     elif isinstance(python_outputs, list) and all(
         (isinstance(x, (int, float, np.number)) for x in python_outputs)
     ):
         python_outputs = np.array(python_outputs).reshape(1, -1)
-        po = numpy_to_prediction_object(python_outputs, trustyai.model.output)[0]
+        po = numpy_to_prediction_object(
+            python_outputs, trustyai.model.output, names=names
+        )[0]
     elif isinstance(python_outputs, np.ndarray):
         if len(python_outputs.shape) == 1:
             python_outputs = python_outputs.reshape(1, -1)
-        po = numpy_to_prediction_object(python_outputs, trustyai.model.output)[0]
+        po = numpy_to_prediction_object(
+            python_outputs, trustyai.model.output, names=names
+        )[0]
     elif isinstance(python_outputs, pd.DataFrame):
         po = df_to_prediction_object(python_outputs, trustyai.model.output)[0]
     elif isinstance(python_outputs, pd.Series):
@@ -265,13 +284,15 @@ def one_output_convert(python_outputs: OneOutputUnionType) -> PredictionOutput:
 
 
 def many_outputs_convert(
-    python_outputs: ManyOutputsUnionType,
+    python_outputs: ManyOutputsUnionType, names: Optional[List[str]] = None
 ) -> List[PredictionOutput]:
     """Convert an object of ManyOutputsUnionType into a List[PredictionOutput]"""
     if isinstance(python_outputs, np.ndarray):
         if len(python_outputs.shape) == 1:
             python_outputs = python_outputs.reshape(1, -1)
-        return numpy_to_prediction_object(python_outputs, trustyai.model.output)
+        return numpy_to_prediction_object(
+            python_outputs, trustyai.model.output, names=names
+        )
     if isinstance(python_outputs, pd.DataFrame):
         return df_to_prediction_object(python_outputs, trustyai.model.output)
     # fallback case is List[PredictionOutput]

--- a/tests/general/test_counterfactualexplainer.py
+++ b/tests/general/test_counterfactualexplainer.py
@@ -166,7 +166,7 @@ def test_counterfactual_with_domain_argument_overwrite():
      a warning"""
     np.random.seed(0)
     data = np.random.rand(1, 5)
-    domained_inputs = one_input_convert(data, [feature_domain((-10, 10)) for _ in range(5)])
+    domained_inputs = one_input_convert(data, feature_domains=[feature_domain((-10, 10)) for _ in range(5)])
     model_weights = np.random.rand(5)
     model = Model(lambda x: np.dot(x, model_weights))
     explainer = CounterfactualExplainer(steps=10_000)

--- a/tests/general/test_limeexplainer.py
+++ b/tests/general/test_limeexplainer.py
@@ -190,3 +190,4 @@ def test_lime_numpy():
         assert oname in explanation.as_dataframe().keys()
         for fname in fnames:
             assert fname in explanation.as_dataframe()[oname].index
+

--- a/tests/general/test_limeexplainer.py
+++ b/tests/general/test_limeexplainer.py
@@ -165,3 +165,28 @@ def test_lime_as_html():
     explainer = LimeExplainer()
     explainer.explain(inputs=data, outputs=model(data), model=model)
     assert True
+
+    explanation = explainer.explain(inputs=data, outputs=model(data), model=model)
+    for score in explanation.as_dataframe()["output-0_score"]:
+        assert score != 0
+
+
+def test_lime_numpy():
+    np.random.seed(0)
+    data = np.random.rand(101, 5)
+    model_weights = np.random.rand(5)
+    predict_function = lambda x: np.stack([np.dot(x, model_weights), 2 * np.dot(x, model_weights)], -1)
+    fnames = ['f{}'.format(x) for x in "abcde"]
+    onames = ['o{}'.format(x) for x in "12"]
+    model = Model(predict_function,
+                  feature_names=fnames,
+                  output_names=onames
+                  )
+
+    explainer = LimeExplainer()
+    explanation = explainer.explain(inputs=data[0], outputs=model(data[0]), model=model)
+
+    for oname in onames:
+        assert oname in explanation.as_dataframe().keys()
+        for fname in fnames:
+            assert fname in explanation.as_dataframe()[oname].index

--- a/tests/general/test_limeexplainer.py
+++ b/tests/general/test_limeexplainer.py
@@ -167,7 +167,7 @@ def test_lime_as_html():
     assert True
 
     explanation = explainer.explain(inputs=data, outputs=model(data), model=model)
-    for score in explanation.as_dataframe()["output-0_score"]:
+    for score in explanation.as_dataframe()["output-0"]['Saliency']:
         assert score != 0
 
 
@@ -189,5 +189,5 @@ def test_lime_numpy():
     for oname in onames:
         assert oname in explanation.as_dataframe().keys()
         for fname in fnames:
-            assert fname in explanation.as_dataframe()[oname].index
+            assert fname in explanation.as_dataframe()[oname]['Feature'].values
 

--- a/tests/general/test_shap.py
+++ b/tests/general/test_shap.py
@@ -112,3 +112,24 @@ def test_shap_as_html():
     shap_explainer = SHAPExplainer(background=background)
     explanation = shap_explainer.explain(inputs=to_explain, outputs=model(to_explain), model=model)
     assert True
+
+
+def test_shap_numpy():
+    np.random.seed(0)
+    data = np.random.rand(101, 5)
+    model_weights = np.random.rand(5)
+    predict_function = lambda x: np.stack([np.dot(x, model_weights), 2 * np.dot(x, model_weights)], -1)
+    fnames = ['f{}'.format(x) for x in "abcde"]
+    onames = ['o{}'.format(x) for x in "12"]
+    model = Model(predict_function,
+                  feature_names=fnames,
+                  output_names=onames
+                  )
+
+    shap_explainer = SHAPExplainer(background=data[1:])
+    explanation = shap_explainer.explain(inputs=data[0], outputs=model(data[0]), model=model)
+
+    for oname in onames:
+        assert oname in explanation.as_dataframe().keys()
+        for fname in fnames:
+            assert fname in explanation.as_dataframe()[oname].index

--- a/tests/general/test_shap.py
+++ b/tests/general/test_shap.py
@@ -132,4 +132,4 @@ def test_shap_numpy():
     for oname in onames:
         assert oname in explanation.as_dataframe().keys()
         for fname in fnames:
-            assert fname in explanation.as_dataframe()[oname].index
+            assert fname in explanation.as_dataframe()[oname]['Feature'].values


### PR DESCRIPTION
Can now specify feature_name and output_names to models

For non-pandas inputs/outputs, the passed feature_names and output_names will be used in PredictionInputs/Outputs

For pandas inputs/outputs, the passed feature_names and output_names are ignored