### PR TITLE
FAI-911: Improve API to declare selections in Python fairness

### DIFF
--- a/src/trustyai/metrics/fairness/group.py
+++ b/src/trustyai/metrics/fairness/group.py
@@ -6,13 +6,16 @@ import pandas as pd
 from jpype import JInt
 from org.kie.trustyai.explainability.metrics import FairnessMetrics
 
-from trustyai.model import Output, Value, PredictionProvider, Model
-from trustyai.utils.data_conversions import pandas_to_trusty
+from trustyai.model import Value, PredictionProvider, Model
+from trustyai.utils.data_conversions import pandas_to_trusty, OneOutputUnionType, one_output_convert
 
 ColumSelector = Union[List[int], List[str]]
 
 
 def _column_selector_to_index(columns: ColumSelector, dataframe: pd.DataFrame):
+    if len(columns) == 0:
+        raise ValueError("Must specify at least one column")
+
     if isinstance(columns[0], str):  # passing column
         columns = dataframe.columns.get_indexer(columns)
     indices = [JInt(c) for c in columns]  # Java casting
@@ -20,28 +23,30 @@ def _column_selector_to_index(columns: ColumSelector, dataframe: pd.DataFrame):
 
 
 def statistical_parity_difference(
-    privileged: pd.DataFrame,
-    unprivileged: pd.DataFrame,
-    favorable: List[Output],
-    outputs: Optional[List[int]] = None,
+        privileged: pd.DataFrame,
+        unprivileged: pd.DataFrame,
+        favorable: OneOutputUnionType,
+        outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Statistical Parity Difference between privileged and unprivileged dataframes"""
+    favorable_prediction_object = one_output_convert(favorable)
     return FairnessMetrics.groupStatisticalParityDifference(
         pandas_to_trusty(privileged, outputs),
         pandas_to_trusty(unprivileged, outputs),
-        favorable,
+        favorable_prediction_object.outputs,
     )
 
 
 # pylint: disable = line-too-long
 def statistical_parity_difference_model(
-    samples: pd.DataFrame,
-    model: Union[PredictionProvider, Model],
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    favorable: List[Output],
+        samples: pd.DataFrame,
+        model: Union[PredictionProvider, Model],
+        privilege_columns: ColumSelector,
+        privilege_values: List[Any],
+        favorable: OneOutputUnionType,
 ) -> float:
     """Calculate Statistical Parity Difference using a samples dataframe and a model"""
+    favorable_prediction_object = one_output_convert(favorable)
     _privilege_values = [Value(v) for v in privilege_values]
     _jsamples = pandas_to_trusty(samples, no_outputs=True)
     return FairnessMetrics.groupStatisticalParityDifference(
@@ -49,33 +54,35 @@ def statistical_parity_difference_model(
         model,
         _column_selector_to_index(privilege_columns, samples),
         _privilege_values,
-        favorable,
+        favorable_prediction_object.outputs,
     )
 
 
 def disparate_impact_ratio(
-    privileged: pd.DataFrame,
-    unprivileged: pd.DataFrame,
-    favorable: List[Output],
-    outputs: Optional[List[int]] = None,
+        privileged: pd.DataFrame,
+        unprivileged: pd.DataFrame,
+        favorable: OneOutputUnionType,
+        outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Disparate Impact Ration between privileged and unprivileged dataframes"""
+    favorable_prediction_object = one_output_convert(favorable)
     return FairnessMetrics.groupDisparateImpactRatio(
         pandas_to_trusty(privileged, outputs),
         pandas_to_trusty(unprivileged, outputs),
-        favorable,
+        favorable_prediction_object.outputs,
     )
 
 
 # pylint: disable = line-too-long
 def disparate_impact_ratio_model(
-    samples: pd.DataFrame,
-    model: Union[PredictionProvider, Model],
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    favorable: List[Output],
+        samples: pd.DataFrame,
+        model: Union[PredictionProvider, Model],
+        privilege_columns: ColumSelector,
+        privilege_values: List[Any],
+        favorable: OneOutputUnionType,
 ) -> float:
     """Calculate Disparate Impact Ration using a samples dataframe and a model"""
+    favorable_prediction_object = one_output_convert(favorable)
     _privilege_values = [Value(v) for v in privilege_values]
     _jsamples = pandas_to_trusty(samples, no_outputs=True)
     return FairnessMetrics.groupDisparateImpactRatio(
@@ -83,18 +90,18 @@ def disparate_impact_ratio_model(
         model,
         _column_selector_to_index(privilege_columns, samples),
         _privilege_values,
-        favorable,
+        favorable_prediction_object.outputs,
     )
 
 
 # pylint: disable = too-many-arguments
 def average_odds_difference(
-    test: pd.DataFrame,
-    truth: pd.DataFrame,
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    positive_class: List[Any],
-    outputs: Optional[List[int]] = None,
+        test: pd.DataFrame,
+        truth: pd.DataFrame,
+        privilege_columns: ColumSelector,
+        privilege_values: OneOutputUnionType,
+        positive_class: List[Any],
+        outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Average Odds between two dataframes"""
     if test.shape != truth.shape:
@@ -115,11 +122,11 @@ def average_odds_difference(
 
 
 def average_odds_difference_model(
-    samples: pd.DataFrame,
-    model: Union[PredictionProvider, Model],
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    positive_class: List[Any],
+        samples: pd.DataFrame,
+        model: Union[PredictionProvider, Model],
+        privilege_columns: ColumSelector,
+        privilege_values: List[Any],
+        positive_class: List[Any],
 ) -> float:
     """Calculate Average Odds for a sample dataframe using the provided model"""
     _jsamples = pandas_to_trusty(samples, no_outputs=True)
@@ -133,12 +140,12 @@ def average_odds_difference_model(
 
 
 def average_predictive_value_difference(
-    test: pd.DataFrame,
-    truth: pd.DataFrame,
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    positive_class: List[Any],
-    outputs: Optional[List[int]] = None,
+        test: pd.DataFrame,
+        truth: pd.DataFrame,
+        privilege_columns: ColumSelector,
+        privilege_values: List[Any],
+        positive_class: List[Any],
+        outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Average Predictive Value Difference between two dataframes"""
     if test.shape != truth.shape:
@@ -159,11 +166,11 @@ def average_predictive_value_difference(
 
 # pylint: disable = line-too-long
 def average_predictive_value_difference_model(
-    samples: pd.DataFrame,
-    model: Union[PredictionProvider, Model],
-    privilege_columns: ColumSelector,
-    privilege_values: List[Any],
-    positive_class: List[Any],
+        samples: pd.DataFrame,
+        model: Union[PredictionProvider, Model],
+        privilege_columns: ColumSelector,
+        privilege_values: List[Any],
+        positive_class: List[Any],
 ) -> float:
     """Calculate Average Predictive Value Difference for a sample dataframe using the provided model"""
     _jsamples = pandas_to_trusty(samples, no_outputs=True)

--- a/src/trustyai/metrics/fairness/group.py
+++ b/src/trustyai/metrics/fairness/group.py
@@ -7,7 +7,11 @@ from jpype import JInt
 from org.kie.trustyai.explainability.metrics import FairnessMetrics
 
 from trustyai.model import Value, PredictionProvider, Model
-from trustyai.utils.data_conversions import pandas_to_trusty, OneOutputUnionType, one_output_convert
+from trustyai.utils.data_conversions import (
+    pandas_to_trusty,
+    OneOutputUnionType,
+    one_output_convert,
+)
 
 ColumSelector = Union[List[int], List[str]]
 
@@ -23,10 +27,10 @@ def _column_selector_to_index(columns: ColumSelector, dataframe: pd.DataFrame):
 
 
 def statistical_parity_difference(
-        privileged: pd.DataFrame,
-        unprivileged: pd.DataFrame,
-        favorable: OneOutputUnionType,
-        outputs: Optional[List[int]] = None,
+    privileged: pd.DataFrame,
+    unprivileged: pd.DataFrame,
+    favorable: OneOutputUnionType,
+    outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Statistical Parity Difference between privileged and unprivileged dataframes"""
     favorable_prediction_object = one_output_convert(favorable)
@@ -39,11 +43,11 @@ def statistical_parity_difference(
 
 # pylint: disable = line-too-long
 def statistical_parity_difference_model(
-        samples: pd.DataFrame,
-        model: Union[PredictionProvider, Model],
-        privilege_columns: ColumSelector,
-        privilege_values: List[Any],
-        favorable: OneOutputUnionType,
+    samples: pd.DataFrame,
+    model: Union[PredictionProvider, Model],
+    privilege_columns: ColumSelector,
+    privilege_values: List[Any],
+    favorable: OneOutputUnionType,
 ) -> float:
     """Calculate Statistical Parity Difference using a samples dataframe and a model"""
     favorable_prediction_object = one_output_convert(favorable)
@@ -59,10 +63,10 @@ def statistical_parity_difference_model(
 
 
 def disparate_impact_ratio(
-        privileged: pd.DataFrame,
-        unprivileged: pd.DataFrame,
-        favorable: OneOutputUnionType,
-        outputs: Optional[List[int]] = None,
+    privileged: pd.DataFrame,
+    unprivileged: pd.DataFrame,
+    favorable: OneOutputUnionType,
+    outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Disparate Impact Ration between privileged and unprivileged dataframes"""
     favorable_prediction_object = one_output_convert(favorable)
@@ -75,11 +79,11 @@ def disparate_impact_ratio(
 
 # pylint: disable = line-too-long
 def disparate_impact_ratio_model(
-        samples: pd.DataFrame,
-        model: Union[PredictionProvider, Model],
-        privilege_columns: ColumSelector,
-        privilege_values: List[Any],
-        favorable: OneOutputUnionType,
+    samples: pd.DataFrame,
+    model: Union[PredictionProvider, Model],
+    privilege_columns: ColumSelector,
+    privilege_values: List[Any],
+    favorable: OneOutputUnionType,
 ) -> float:
     """Calculate Disparate Impact Ration using a samples dataframe and a model"""
     favorable_prediction_object = one_output_convert(favorable)
@@ -96,12 +100,12 @@ def disparate_impact_ratio_model(
 
 # pylint: disable = too-many-arguments
 def average_odds_difference(
-        test: pd.DataFrame,
-        truth: pd.DataFrame,
-        privilege_columns: ColumSelector,
-        privilege_values: OneOutputUnionType,
-        positive_class: List[Any],
-        outputs: Optional[List[int]] = None,
+    test: pd.DataFrame,
+    truth: pd.DataFrame,
+    privilege_columns: ColumSelector,
+    privilege_values: OneOutputUnionType,
+    positive_class: List[Any],
+    outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Average Odds between two dataframes"""
     if test.shape != truth.shape:
@@ -122,11 +126,11 @@ def average_odds_difference(
 
 
 def average_odds_difference_model(
-        samples: pd.DataFrame,
-        model: Union[PredictionProvider, Model],
-        privilege_columns: ColumSelector,
-        privilege_values: List[Any],
-        positive_class: List[Any],
+    samples: pd.DataFrame,
+    model: Union[PredictionProvider, Model],
+    privilege_columns: ColumSelector,
+    privilege_values: List[Any],
+    positive_class: List[Any],
 ) -> float:
     """Calculate Average Odds for a sample dataframe using the provided model"""
     _jsamples = pandas_to_trusty(samples, no_outputs=True)
@@ -140,12 +144,12 @@ def average_odds_difference_model(
 
 
 def average_predictive_value_difference(
-        test: pd.DataFrame,
-        truth: pd.DataFrame,
-        privilege_columns: ColumSelector,
-        privilege_values: List[Any],
-        positive_class: List[Any],
-        outputs: Optional[List[int]] = None,
+    test: pd.DataFrame,
+    truth: pd.DataFrame,
+    privilege_columns: ColumSelector,
+    privilege_values: List[Any],
+    positive_class: List[Any],
+    outputs: Optional[List[int]] = None,
 ) -> float:
     """Calculate Average Predictive Value Difference between two dataframes"""
     if test.shape != truth.shape:
@@ -166,11 +170,11 @@ def average_predictive_value_difference(
 
 # pylint: disable = line-too-long
 def average_predictive_value_difference_model(
-        samples: pd.DataFrame,
-        model: Union[PredictionProvider, Model],
-        privilege_columns: ColumSelector,
-        privilege_values: List[Any],
-        positive_class: List[Any],
+    samples: pd.DataFrame,
+    model: Union[PredictionProvider, Model],
+    privilege_columns: ColumSelector,
+    privilege_values: List[Any],
+    positive_class: List[Any],
 ) -> float:
     """Calculate Average Predictive Value Difference for a sample dataframe using the provided model"""
     _jsamples = pandas_to_trusty(samples, no_outputs=True)


### PR DESCRIPTION
Allow `data_conversion` inputs to be used to select favorable outcomes in group fairness metrics.