### PR TITLE
FAI-914: Add NumPy support for group fairness metrics

### DIFF
--- a/tests/general/common.py
+++ b/tests/general/common.py
@@ -2,6 +2,8 @@
 """Common methods and models for tests"""
 import os
 import sys
+from typing import Optional, List
+
 import numpy as np
 import pandas as pd  # pylint: disable=unused-import
 
@@ -21,3 +23,20 @@ def mock_feature(value, name='f-num'):
 def sum_skip_model(inputs: np.ndarray) -> np.ndarray:
     """SumSkip test model"""
     return np.sum(inputs[:, [i for i in range(inputs.shape[1]) if i != 5]], 1)
+
+
+def create_random_dataframe(weights: Optional[List[float]] = None):
+    """Create a simple random Pandas dataframe"""
+    from sklearn.datasets import make_classification
+    if not weights:
+        weights = [0.9, 0.1]
+
+    X, y = make_classification(n_samples=5000, n_features=2, n_informative=2, n_redundant=0, n_repeated=0, n_classes=2,
+                               n_clusters_per_class=2, class_sep=2, flip_y=0, weights=weights,
+                               random_state=23)
+
+    return pd.DataFrame({
+        'x1': X[:, 0],
+        'x2': X[:, 1],
+        'y': y
+    })

--- a/tests/general/test_conversions.py
+++ b/tests/general/test_conversions.py
@@ -12,7 +12,7 @@ from trustyai.utils.data_conversions import (
     one_input_convert,
     one_output_convert,
     many_inputs_convert,
-    many_outputs_convert
+    many_outputs_convert, to_trusty_dataframe
 )
 from org.kie.trustyai.explainability.model import Type
 
@@ -167,8 +167,8 @@ def test_one_input_conversion():
 
     converted = [one_input_convert(x) for x in to_convert]
 
-    for i in range(len(converted)-1):
-        assert converted[i].equals(converted[i+1])
+    for i in range(len(converted) - 1):
+        assert converted[i].equals(converted[i + 1])
 
 
 def test_one_input_conversion_domained():
@@ -191,9 +191,9 @@ def test_one_input_conversion_domained():
 
     for i in range(len(converted) - 1):
         for j in range(n_feats):
-            assert converted[i].getFeatures().get(j).getDomain().getLowerBound()\
+            assert converted[i].getFeatures().get(j).getDomain().getLowerBound() \
                    == domain_bounds[j][0]
-            assert converted[i].getFeatures().get(j).getDomain().getUpperBound()\
+            assert converted[i].getFeatures().get(j).getDomain().getUpperBound() \
                    == domain_bounds[j][1]
 
         assert converted[i].equals(converted[i + 1])
@@ -341,3 +341,16 @@ def test_many_inputs_conversion_domained():
 
     for i in range(n_datapoints):
         assert ta_numpy1[i].equals(ta_df[i])
+
+
+def test_numpy_to_trusty_dataframe():
+    """Test converting a NumPy array to a TrustyAI dataframe"""
+    arr = create_random_dataframe().to_numpy()
+
+    tdf = to_trusty_dataframe(data=arr, feature_names=["x1", "x2", "y"])
+
+    assert tdf.getColumnDimension() == 3
+    assert tdf.getRowDimension() == 5000
+    assert list(tdf.getColumnNames()) == ["x1", "x2", "y"]
+    assert tdf.getInputsCount() == 2
+    assert tdf.getOutputsCount() == 1


### PR DESCRIPTION
Add NumPy support in group fairness metrics.