### PR TITLE
Add Git changelog automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,259 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [unreleased]
+
+
+### [FAI-825](https://issues.redhat.com/browse/FAI-825)
+
+
+- Add feature and output name specification to models ([#130](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/130))
+
+
+### [FAI-841](https://issues.redhat.com/browse/FAI-841)
+
+
+- Python benchmarks failing since namespace migration ([#82](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/82))
+
+
+### [FAI-849](https://issues.redhat.com/browse/FAI-849)
+
+
+- Tyrus dashboard ([#97](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/97))
+
+
+### [FAI-855](https://issues.redhat.com/browse/FAI-855)
+
+
+- Move arrow converters into exp-core ([#101](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/101))
+
+
+### [FAI-863](https://issues.redhat.com/browse/FAI-863)
+
+
+- XAI-Bench ([#109](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/109))
+- XAIbench submodule tracking main branch, fork of xai-bench ([#111](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/111))
+
+
+### [FAI-864](https://issues.redhat.com/browse/FAI-864)
+
+
+- Fix failing RtD build after to pip migration ([#100](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/100))
+
+
+### [FAI-867](https://issues.redhat.com/browse/FAI-867)
+
+
+- Add Java 9+ Arrow compatibility flags ([#103](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/103))
+
+
+### [FAI-879](https://issues.redhat.com/browse/FAI-879)
+
+
+- Sync version with exp-core ([#107](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/107))
+
+
+### [FAI-880](https://issues.redhat.com/browse/FAI-880)
+
+
+- Move explainers into separate files ([#110](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/110))
+
+
+### [FAI-881](https://issues.redhat.com/browse/FAI-881)
+
+
+- Upgrade Pylint version ([#112](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/112))
+
+
+### [FAI-882](https://issues.redhat.com/browse/FAI-882)
+
+
+- Add kwargs to explainers ([#113](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/113))
+
+
+### [FAI-884](https://issues.redhat.com/browse/FAI-884)
+
+
+- Add SHAP background generators to bindings ([#117](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/117))
+
+
+### [FAI-886](https://issues.redhat.com/browse/FAI-886)
+
+
+- Unified input/output types, conversion functions, and docstrings ([#116](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/116))
+
+
+### [FAI-887](https://issues.redhat.com/browse/FAI-887)
+
+
+- Generalize ExplanationResults ([#115](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/115))
+
+
+### [FAI-889](https://issues.redhat.com/browse/FAI-889)
+
+
+- Allow non-string categorical feature domains ([#118](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/118))
+
+
+### [FAI-892](https://issues.redhat.com/browse/FAI-892)
+
+
+- Tyrus TempDirectory ([#121](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/121))
+
+
+### [FAI-893](https://issues.redhat.com/browse/FAI-893)
+
+
+- Make test plots non-blocking by default ([#120](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/120))
+
+
+### [FAI-896](https://issues.redhat.com/browse/FAI-896)
+
+
+- Doc standardization and cleanup ([#126](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/126))
+
+
+### [FAI-897](https://issues.redhat.com/browse/FAI-897)
+
+
+- Add bokeh dependency ([#123](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/123))
+
+
+### [FAI-900](https://issues.redhat.com/browse/FAI-900)
+
+
+- Added feature domain argument to counterfactuals ([#128](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/128))
+
+
+### [FAI-901](https://issues.redhat.com/browse/FAI-901)
+
+
+- Increased input/ouput conversion flexibility ([#127](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/127))
+
+
+### [FAI-903](https://issues.redhat.com/browse/FAI-903)
+
+
+- Add group fairness Python bindings ([#129](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/129))
+
+
+### [FAI-911](https://issues.redhat.com/browse/FAI-911)
+
+
+- Improve API to declare selections in Python fairness ([#132](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/132))
+
+## [0.2.5] - 2022-09-14
+
+
+### Bug Fixes
+
+
+- Fixed linting, adding doc build reqs to requirements-dev
+
+- Fixed line-too-long linting errors
+
+- Fixed distutils import formatting
+
+- Fixed conflicts with FAI-806, added build output
+
+- Fixed incorrect LIME typing
+
+- Fixed typo in Output field
+
+- Fixed rtd.yaml python version inconsistency
+
+- Fixed path in rtd install config
+
+- Fixed custom.css path
+
+- Fixed failing tests
+
+- Fixed black-induced line-too-long
+
+- Fixed failing shapresults.getSaliencies call
+
+- Fixed linting errors re. import order
+
+- Fixed failing initializer tests
+
+- Fixed unrelated explainers change
+
+- Fixed incorrect ShapResults.get_saliency output type
+
+- Fixed broken favicon
+
+- Fixed linting issue
+
+- Fixed enumeration tuple issue
+
+- Fixed failing SHAP tests, improved output name imputation in Model
+
+- Fixed overzealous find and replace of trustyai
+
+- Fixed overzealous find and replace of trustyai part 2
+
+- Fixed broken output casting for 1d output arrays
+
+
+
+### [FAI-797b](https://issues.redhat.com/browse/FAI-797b)
+
+
+- Include doc link in README
+
+## [0.2.4] - 2022-06-16
+
+## [0.2.3] - 2022-05-12
+
+
+### Bug Fixes
+
+
+- Fixed missing final newline
+
+
+## [0.2.2] - 2022-04-25
+
+## [0.2.1] - 2022-04-22
+
+## [0.2.0] - 2022-04-22
+
+
+### Bug Fixes
+
+
+- Fixed linting issues
+
+- Fixed linting issues re. the glob checker for wildcard paths
+
+- Fixed line-too-long linting issue in model/__init__
+
+
+
+### Refactor
+
+
+- Refactored arrow inclusion; mvn pulls dependencies, then includes precompiled arrowconverters jar
+
+
+## [0.1.1] - 2022-03-09
+
+## [0.0.9] - 2022-02-17
+
+## [0.0.8] - 2022-02-17
+
+## [0.0.7] - 2022-02-17
+
+## [0.0.6] - 2022-02-17
+
+## [0.0.5] - 2022-01-22
+
+## [0.0.4] - 2022-01-22
+
+## [0.0.3] - 2021-11-04
+
+## [0.0.2] - 2021-08-09
+
+## [0.0.1] - 2021-07-21
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,71 @@
+# configuration file for git-cliff (0.1.0)
+
+[changelog]
+# changelog header
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+"""
+# template for the changelog body
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    {% if group is starting_with("FAI-") %}
+    {% set issue_id = group | trim_start_matches(pat="FAI-") -%}
+    ### [FAI-{{ issue_id }}](https://issues.redhat.com/browse/FAI-{{ issue_id }})
+    {% else %}
+    ### {{ group | upper_first }}
+    {% endif %}
+    {% for commit in commits %}
+        - {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message | upper_first }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+# remove the leading and trailing whitespace from the template
+trim = true
+# changelog footer
+footer = ""
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+conventional_commits = true
+# filter out the commits that are not conventional
+filter_unconventional = false
+# process each line of a commit as an individual commit
+split_commits = false
+# regex for preprocessing the commit messages
+commit_preprocessors = [
+    { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/trustyai-explainability/trustyai-explainability-python/pull/${2}))"},
+    { pattern = 'FAI-([0-9]+)\s', replace = "[FAI-${1}](https://issues.redhat.com/browse/FAI-${1})"},
+    # { pattern = 'FAI-([0-9]+)\s', replace = "[FAI-${1}](https://issues.redhat.com/browse/FAI-${1})"},
+]
+# regex for parsing and grouping commits
+commit_parsers = [
+    { message = "^feat", group = "Features"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^perf", group = "Performance"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^style", group = "Styling"},
+    { message = "^test", group = "Testing"},
+    { message = "^chore\\(release\\): prepare for", skip = true},
+    { message = "^chore", group = "Miscellaneous Tasks"},
+    { body = ".*security", group = "Security"},
+]
+# filter out the commits that are not matched by commit parsers
+filter_commits = false
+# glob pattern for matching git tags
+tag_pattern = "[0-9]*"
+# regex for skipping tags
+skip_tags = "v0.1.0-beta.1"
+# regex for ignoring tags
+ignore_tags = ""
+# sort the tags chronologically
+date_order = false
+# sort the commits inside sections by oldest/newest order
+sort_commits = "oldest"


### PR DESCRIPTION
Automation provided by [git-cliff](https://github.com/orhun/git-cliff).

Ideally commits should follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification, but it's configured in a way that `FAI-XYZ: $message` (as typically used) is also accepted.