### PR TITLE
FAI-917: Add error message capturing within Python models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ build-backend = "setuptools.build_meta"
 package-dir = { "" = "src" }
 
 [tool.pytest.ini_options]
+log_cli = true
 addopts = '-m="not block_plots"'
 markers = [
     "block_plots: Test plots will block execution of subsequent tests until closed"

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -348,7 +348,7 @@ class Model:
                 logging.error(
                     " The error message has been captured and reproduced below:"
                 )
-                logging.error(" " + str(traceback.format_exc()))
+                logging.error(" %s", traceback.format_exc())
                 raise e
 
         return wrapper

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -343,7 +343,7 @@ class Model:
                 return predict_fun(x)
             except Exception as e:
                 logging.error(
-                    "ERROR: Fatal runtime error within supplied `predict_func`"
+                    "ERROR: Fatal runtime error within supplied `predict_fun`"
                     " to trustyai.Model"
                 )
                 logging.error(

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -343,13 +343,12 @@ class Model:
                 return predict_fun(x)
             except Exception as e:
                 logging.error(
-                    "ERROR: Fatal runtime error within supplied `predict_fun`"
-                    " to trustyai.Model"
+                    " Fatal runtime error within the `predict_fun` supplied to trustyai.Model"
                 )
                 logging.error(
-                    "The error message has been captured and reproduced below:"
+                    " The error message has been captured and reproduced below:"
                 )
-                logging.error(traceback.format_exc())
+                logging.error(" " + str(traceback.format_exc()))
                 raise e
 
         return wrapper

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -325,8 +325,6 @@ class Model:
                 situations where it is advantageous to do so.
         """
 
-
-
         self.predict_fun = self._error_catcher(predict_fun)
         self.kwargs = kwargs
 
@@ -338,12 +336,19 @@ class Model:
         self._set_nonarrow()
 
     def _error_catcher(self, predict_fun):
+        """Wrapper for predict function to capture errors to Python logger before the JVM dies"""
+
         def wrapper(x):
             try:
                 return predict_fun(x)
             except Exception as e:
-                logging.error("ERROR: Fatal runtime error within supplied `predict_func` to trustyai.Model")
-                logging.error("The error message has been captured and reproduced below:")
+                logging.error(
+                    "ERROR: Fatal runtime error within supplied `predict_func`"
+                    " to trustyai.Model"
+                )
+                logging.error(
+                    "The error message has been captured and reproduced below:"
+                )
                 logging.error(traceback.format_exc())
                 raise e
 
@@ -500,7 +505,7 @@ class Model:
                 self.previous_model_state = self.model.prediction_provider
                 self.model._set_arrow(self.paradigm_input)
 
-        def __exit__(self, exit_type, value, traceback):
+        def __exit__(self, exit_type, value, tb):
             if self.model_is_python:
                 self.model.prediction_provider = self.previous_model_state
 
@@ -519,7 +524,7 @@ class Model:
                 self.previous_model_state = self.model.prediction_provider
                 self.model._set_nonarrow()
 
-        def __exit__(self, exit_type, value, traceback):
+        def __exit__(self, exit_type, value, tb):
             if self.model_is_python:
                 self.model.prediction_provider = self.previous_model_state
 

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -1,5 +1,6 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
 """Test model provider interface"""
+from trustyai.explainers import LimeExplainer
 
 from common import *
 from trustyai.model import Model, Dataset, feature
@@ -46,3 +47,14 @@ def test_cast_output_arrow():
         output_val = m.predictAsync(pis).get()
         assert len(output_val) == 25
 
+
+def test_error_model(caplog):
+    """test that a broken model spits out useful debugging info"""
+    m = Model(lambda x: str(x) - str(x))
+    try:
+        LimeExplainer().explain(0, 0, m)
+    except Exception:
+        pass
+
+    assert "Fatal runtime error within supplied `predict_func` to trustyai.Model" in caplog.text
+    assert "TypeError: unsupported operand type(s) for -: 'str' and 'str'" in caplog.text

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -56,5 +56,5 @@ def test_error_model(caplog):
     except Exception:
         pass
 
-    assert "Fatal runtime error within supplied `predict_func` to trustyai.Model" in caplog.text
+    assert "Fatal runtime error" in caplog.text
     assert "TypeError: unsupported operand type(s) for -: 'str' and 'str'" in caplog.text


### PR DESCRIPTION
If we log and capture error messages from within the `predict_fun` we can display them before the JVM crashes, making debugging a whole lot easier.

Before:
<img width="901" alt="Screenshot 2022-12-19 at 3 09 13 PM" src="https://user-images.githubusercontent.com/20345051/208456752-f0543b13-f30f-465a-b1ce-ef9b8dcc7b19.png">

After:
<img width="907" alt="Screenshot 2022-12-19 at 3 14 04 PM" src="https://user-images.githubusercontent.com/20345051/208457860-55e5c05c-d777-402e-84e7-7650e2fda3da.png">

