### PR TITLE
FAI-926: Implement custom counterfactual goal criteria

### DIFF
--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -1,7 +1,7 @@
 """Explainers.countefactual module"""
 # pylint: disable = import-error, too-few-public-methods, wrong-import-order, line-too-long,
 # pylint: disable = unused-argument
-from typing import Callable, Optional, Tuple, Union, List
+from typing import Optional, Union, List
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import pandas as pd
@@ -17,7 +17,8 @@ from trustyai.utils._visualisation import (
 from trustyai.model import (
     counterfactual_prediction,
     PredictionInput,
-    Model, GoalCriteria,
+    Model,
+    GoalCriteria,
 )
 
 from trustyai.utils.data_conversions import (
@@ -241,7 +242,7 @@ class CounterfactualExplainer:
             data_distribution=data_distribution,
             uuid=uuid,
             timeout=timeout,
-            criteria=criteria
+            criteria=criteria,
         )
 
         with Model.NonArrowTransmission(model):

--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -1,7 +1,7 @@
 """Explainers.countefactual module"""
 # pylint: disable = import-error, too-few-public-methods, wrong-import-order, line-too-long,
 # pylint: disable = unused-argument
-from typing import Optional, Union, List
+from typing import Callable, Optional, Tuple, Union, List
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import pandas as pd
@@ -17,9 +17,8 @@ from trustyai.utils._visualisation import (
 from trustyai.model import (
     counterfactual_prediction,
     PredictionInput,
-    Model,
+    Model, GoalCriteria,
 )
-
 
 from trustyai.utils.data_conversions import (
     prediction_object_to_numpy,
@@ -184,12 +183,13 @@ class CounterfactualExplainer:
     def explain(
         self,
         inputs: OneInputUnionType,
-        goal: OneOutputUnionType,
         model: Union[PredictionProvider, Model],
+        goal: Optional[OneOutputUnionType] = None,
         feature_domains: List[FeatureDomain] = None,
         data_distribution: Optional[DataDistribution] = None,
         uuid: Optional[_uuid.UUID] = None,
         timeout: Optional[float] = None,
+        criteria: Optional[GoalCriteria] = None,
     ) -> CounterfactualResult:
         r"""Request for a counterfactual explanation given a list of features, goals and a
         :class:`~PredictionProvider`
@@ -217,7 +217,9 @@ class CounterfactualExplainer:
         uuid : Optional[:class:`_uuid.UUID`]
             The UUID to use during search.
         timeout : Optional[float]
-                The timeout time in seconds of the counterfactual explanation.
+            The timeout time in seconds of the counterfactual explanation.
+        criteria : Optional[:class:`GoalCriteria`]
+            An optional custom scoring function, wrapped as a :class:`GoalCriteria`.
 
         Returns
         -------
@@ -226,6 +228,10 @@ class CounterfactualExplainer:
         """
         feature_names = model.feature_names if isinstance(model, Model) else None
         output_names = model.output_names if isinstance(model, Model) else None
+
+        if not goal and not criteria:
+            raise ValueError("Either one goal or criteria must be provided.")
+
         _prediction = counterfactual_prediction(
             input_features=one_input_convert(
                 inputs, feature_names=feature_names, feature_domains=feature_domains
@@ -236,6 +242,7 @@ class CounterfactualExplainer:
             data_distribution=data_distribution,
             uuid=uuid,
             timeout=timeout,
+            criteria=criteria
         )
 
         with Model.NonArrowTransmission(model):

--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -228,8 +228,7 @@ class CounterfactualExplainer:
         """
         feature_names = model.feature_names if isinstance(model, Model) else None
         output_names = model.output_names if isinstance(model, Model) else None
-
-        if not goal and not criteria:
+        if goal is None and criteria is None:
             raise ValueError("Either one goal or criteria must be provided.")
 
         _prediction = counterfactual_prediction(

--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -229,7 +229,7 @@ class CounterfactualExplainer:
         feature_names = model.feature_names if isinstance(model, Model) else None
         output_names = model.output_names if isinstance(model, Model) else None
         if goal is None and criteria is None:
-            raise ValueError("Either one goal or criteria must be provided.")
+            raise ValueError("Either a goal or criteria must be provided.")
 
         _prediction = counterfactual_prediction(
             input_features=one_input_convert(

--- a/src/trustyai/model/__init__.py
+++ b/src/trustyai/model/__init__.py
@@ -24,6 +24,7 @@ from trustyai.utils.data_conversions import (
     prediction_object_to_pandas,
     data_conversion_docstring,
 )
+from trustyai.model.domain import feature_domain
 
 from org.kie.trustyai.explainability.model import (
     CounterfactualPrediction as _CounterfactualPrediction,
@@ -54,7 +55,6 @@ from org.apache.arrow.vector import VectorSchemaRoot as _VectorSchemaRoot
 from org.kie.trustyai.arrow import ArrowConverters, PPAWrapper
 from org.kie.trustyai.explainability.model.domain import (
     EmptyFeatureDomain as _EmptyFeatureDomain,
-    feature_domain,
 )
 
 from java.lang import Long

--- a/tests/general/test_counterfactualexplainer.py
+++ b/tests/general/test_counterfactualexplainer.py
@@ -149,7 +149,23 @@ def test_counterfactual_match_goal_criteria_numpy():
 
     assert result.proposed_features_array[0][0] == approx(result.proposed_features_array[0][1]**2, 0.1)
 
+def test_counterfactual_missing_goal_criteria():
+    """Must throw an error if both goals and criteria are missing"""
+    features = [
+        feature(name=f"f-num{i + 1}", value=10.0, dtype="number", domain=(0.0, 1000.0)) for i in range(3)
+    ]
 
+    explainer = CounterfactualExplainer(steps=10000)
+
+    model = TestModels.getSumSkipTwoOutputModel(3)
+
+    with pytest.raises(Exception) as e:
+        explainer.explain(
+            inputs=features,
+            model=model,
+        )
+
+    assert str(e.value) == 'Either a goal or criteria must be provided.'
 
 def test_counterfactual_match_python_model():
     """Test if there's a valid counterfactual with a Python model"""

--- a/tests/general/test_counterfactualexplainer.py
+++ b/tests/general/test_counterfactualexplainer.py
@@ -96,7 +96,7 @@ def test_counterfactual_match_goal_criteria():
         feature(name=f"f-num{i + 1}", value=10.0, dtype="number", domain=(0.0, 1000.0)) for i in range(3)
     ]
 
-    explainer = CounterfactualExplainer(steps=20000)
+    explainer = CounterfactualExplainer(steps=10000)
     criteria = GoalCriteria(custom_goal)
 
     model = TestModels.getSumSkipTwoOutputModel(3)
@@ -112,12 +112,10 @@ def test_counterfactual_match_goal_criteria():
         total_sum += entity.as_feature().value.as_number()
         print(entity)
 
-    print("Counterfactual match:")
+    print("Counterfactual match, (sum-but3)^2==sum-but3*2 :")
     print(result._result.output[0].outputs)
 
-    # assert total_sum <= center + epsilon
-    # assert total_sum >= center - epsilon
-    # assert result._result.isValid()
+    assert result.proposed_features_array[0][0] == approx(result.proposed_features_array[0][1]**2, 0.1)
 
 
 def test_counterfactual_match_python_model():

--- a/tests/general/test_model.py
+++ b/tests/general/test_model.py
@@ -1,6 +1,5 @@
 # pylint: disable=import-error, wrong-import-position, wrong-import-order, invalid-name
 """Test model provider interface"""
-from trustyai.explainers import LimeExplainer
 
 from common import *
 from trustyai.model import Model, Dataset, feature
@@ -47,14 +46,3 @@ def test_cast_output_arrow():
         output_val = m.predictAsync(pis).get()
         assert len(output_val) == 25
 
-
-def test_error_model(caplog):
-    """test that a broken model spits out useful debugging info"""
-    m = Model(lambda x: str(x) - str(x))
-    try:
-        LimeExplainer().explain(0, 0, m)
-    except Exception:
-        pass
-
-    assert "Fatal runtime error" in caplog.text
-    assert "TypeError: unsupported operand type(s) for -: 'str' and 'str'" in caplog.text


### PR DESCRIPTION
[FAI-926](https://issues.redhat.com/browse/FAI-926)

This PR adds programmable goal criteria to the Python counterfactuals.

Goal criteria allow to pass arbitrarily complex functions as a goal (using the CF proposal predictions as inputs) for scenarios where a static goal might not be sufficient.
The criteria can be any Python function and may take either Pandas dataframes or Numpy arrays as inputs and must return a tuple consisting of distance and score.

This PR also abstracts some functionality previously on the `Model` wrapper class to a more generic `CallableWrapper`, since the goal criteria shares some common functionality with `Model`.
