### PR TITLE
FAI-916: Fixed Categorical/CatNum feature casting issues

### DIFF
--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -27,7 +27,7 @@ from trustyai.utils.data_conversions import (
     OneInputUnionType,
     OneOutputUnionType,
     data_conversion_docstring,
-    one_input_convert,
+    one_input_convert, java_string_capture,
 )
 
 from org.kie.trustyai.explainability.local.counterfactual import (
@@ -79,6 +79,14 @@ class CounterfactualResult(ExplanationResults):
             [PredictionInput([entity.as_feature() for entity in self._result.entities])]
         )
 
+
+    def _get_feature_difference(self, value_pair):
+        proposed, original = value_pair
+        try:
+            return proposed - original
+        except:
+            return "{} -> {}".format(original, proposed)
+
     def as_dataframe(self) -> pd.DataFrame:
         """
         Return the counterfactual result as a dataframe
@@ -99,15 +107,15 @@ class CounterfactualResult(ExplanationResults):
         features = self._result.getFeatures()
 
         data = {}
-        data["features"] = [f"{entity.as_feature().getName()}" for entity in entities]
-        data["proposed"] = [entity.as_feature().value.as_obj() for entity in entities]
-        data["original"] = [
-            feature.getValue().getUnderlyingObject() for feature in features
+        data["Features"] = [f"{entity.as_feature().getName()}" for entity in entities]
+        data["Proposed"] = [java_string_capture(entity.as_feature().value.as_obj()) for entity in entities]
+        data["Original"] = [
+            java_string_capture(feature.getValue().getUnderlyingObject()) for feature in features
         ]
         data["constrained"] = [feature.is_constrained for feature in features]
 
         dfr = pd.DataFrame.from_dict(data)
-        dfr["difference"] = dfr.proposed - dfr.original
+        dfr["Difference"] = dfr[["Proposed", "Original"]].apply(self._get_feature_difference, 1)
         return dfr
 
     def as_html(self) -> pd.io.formats.style.Styler:

--- a/src/trustyai/model/domain.py
+++ b/src/trustyai/model/domain.py
@@ -2,7 +2,8 @@
 """Conversion method between Python and TrustyAI Java types"""
 from typing import Optional, Tuple, List, Union
 
-from jpype import _jclass
+import jpype
+from jpype import _jclass, JArray
 
 from org.kie.trustyai.explainability.model.domain import (
     FeatureDomain,
@@ -60,16 +61,21 @@ def feature_domain(values: Optional[Union[Tuple, List]]) -> Optional[FeatureDoma
             domain = NumericalFeatureDomain.create(values[0], values[1])
 
         elif isinstance(values, list):
-            java_array = _jclass.JClass("java.util.Arrays").asList(values)
             if isinstance(values[0], bool) and isinstance(values[1], bool):
+                java_values = [jpype.JBoolean(v) for v in values]
+                java_array = _jclass.JClass("java.util.Arrays").asList(java_values)
                 domain = ObjectFeatureDomain.create(java_array)
             elif isinstance(values[0], (float, int)) and isinstance(
                 values[1], (float, int)
             ):
+                if isinstance(values[0], float):
+                    java_values = [jpype.JDouble(v) for v in values]
+                else:
+                    java_values = [jpype.JInt(v) for v in values]
+                java_array = _jclass.JClass("java.util.Arrays").asList(java_values)
                 domain = CategoricalNumericalFeatureDomain.create(java_array)
-            elif isinstance(values[0], str):
-                domain = CategoricalFeatureDomain.create(java_array)
             else:
+                java_array = _jclass.JClass("java.util.Arrays").asList(values)
                 domain = ObjectFeatureDomain.create(java_array)
 
         else:


### PR DESCRIPTION
Python ints were being erroneously converted to JLongs in the data conversions and feature domains. 

Additionally, all numeric types were assumed to be `Type.NUMBER`; now, the supplied feature domains can override the assumed type with an explicitly provided type. 