### PR TITLE
FAI-978: Add ODH notebook image dependencies test to CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ dev = [
     "setuptools",
     "twine==3.4.2",
     "wheel~=0.38.4",
-    "xgboost==1.4.2"
+    "xgboost==1.4.2",
+    "dparse==0.6.2"
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,17 @@
+JPype1==1.4.1
+black~=22.12.0
+click==8.0.4
+joblib~=1.2.0
+jupyterlab~=3.5.3
+numpydoc==1.5.0
+pyarrow==7.0.0
+pylint==2.15.6
+pytest~=7.2.1
+pytest-benchmark==4.0.0
+pytest-forked~=1.6.0
+scikit-learn~=1.2.1
+setuptools
+twine==3.4.2
+wheel~=0.38.4
+xgboost==1.4.2
+dparse==0.6.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-JPype1==1.4.1
-matplotlib==3.5.1
-pandas==1.2.5
+Jpype1==1.4.1
 pyarrow==7.0.0
-bokeh==2.4.3
+matplotlib~=3.6.3
+pandas~=1.5.3
+numpy~=1.24.1
+jupyter-bokeh~=3.0.5

--- a/tests/general/test_dependencies.py
+++ b/tests/general/test_dependencies.py
@@ -1,0 +1,45 @@
+import urllib.request
+from dparse import parse, filetypes
+
+VERSION = "datascience/ubi9-python-3.9"
+
+def test_dependencies():
+    '''Tests whether TrustyAI's dependencies are compatible with ODH workbench-image's https://github.com/opendatahub-io/notebooks/tree/main/jupyter/datascience/ubi9-python-3.9'''
+    # download the pipfile
+    urllib.request.urlretrieve(
+        f"https://raw.githubusercontent.com/opendatahub-io/notebooks/main/jupyter/{VERSION}/Pipfile",
+        "/tmp/Pipfile")
+
+    with open('./requirements.txt', 'r') as file:
+        reqtxt = parse(file.read(), file_type=filetypes.requirements_txt)
+
+    with open('./requirements-dev.txt', 'r') as file:
+        reqdevtxt = parse(file.read(), file_type=filetypes.requirements_txt)
+
+    with open('/tmp/Pipfile', 'r') as file:
+        pipfile = parse(file.read(), file_type=filetypes.pipfile)
+
+    reqtxt_names = {dependency.name: dependency for dependency in reqtxt.dependencies}
+    reqdevtxt_names = {dependency.name: dependency for dependency in reqdevtxt.dependencies}
+
+    mismatched_specs = []
+
+    for dependency in pipfile.dependencies:
+        if dependency.name in reqtxt_names.keys():
+            print(f"{dependency} found")
+            trusty_specs = reqtxt_names[dependency.name].specs
+            if dependency.specs == trusty_specs:
+                print(f"\tSpecs match ({dependency.specs})")
+            else:
+                print(f"\tSpecs do not match ({dependency.specs} ODH vs. {reqtxt_names[dependency.name].specs} TrustyAI)")
+                mismatched_specs.append(dependency)
+        if dependency.name in reqdevtxt_names.keys():
+            print(f"{dependency} found")
+            trusty_specs = reqdevtxt_names[dependency.name].specs
+            if dependency.specs == trusty_specs:
+                print(f"\tSpecs match ({dependency.specs})")
+            else:
+                print(f"\tSpecs do not match ({dependency.specs} ODH vs. {reqtxt_names[dependency.name].specs} TrustyAI)")
+                mismatched_specs.append(dependency)
+
+    assert len(mismatched_specs) == 0


### PR DESCRIPTION
[FAI-978](https://issues.redhat.com/browse/FAI-978):

This PR adds a test in CI to check whether TrustyAI's dependencies are compatible with [ODH notebook](https://github.com/opendatahub-io/notebooks) ones.