### PR TITLE
RHODS-7947: Reduce logging level of exp-core in Python TrustyAI

### DIFF
--- a/src/trustyai/initializer.py
+++ b/src/trustyai/initializer.py
@@ -17,7 +17,9 @@ from jpype import _jcustomizer, _jclass
 
 DEFAULT_ARGS = (
     "--add-opens=java.base/java.nio=ALL-UNNAMED",
-)  # see https://arrow.apache.org/docs/java/install.html#java-compatibility
+    # see https://arrow.apache.org/docs/java/install.html#java-compatibility
+    "-Dorg.slf4j.simpleLogger.defaultLogLevel=error",
+)
 
 
 def _get_default_path():


### PR DESCRIPTION
Java logging in Python TrustyAI can be noisy, especially in counterfactuals where the log level is `warn` and within Jupyter notebooks.
This PR reduces the Java logging level to `error` (only when used from Python).