### PR TITLE
Added option to bypass mandatory plotting of explanation results

### DIFF
--- a/src/trustyai/explainers/counterfactuals.py
+++ b/src/trustyai/explainers/counterfactuals.py
@@ -123,7 +123,7 @@ class CounterfactualResult(ExplanationResults):
         """
         return self.as_dataframe().style
 
-    def plot(self, block=True) -> None:
+    def plot(self, block=True, call_show=True) -> None:
         """
         Plot the counterfactual result.
         """
@@ -145,7 +145,8 @@ class CounterfactualResult(ExplanationResults):
                 x="features", color={"proposed": colour, "original": "black"}
             )
             plot.set_title("Counterfactual")
-            plt.show(block=block)
+            if call_show:
+                plt.show(block=block)
 
 
 class CounterfactualExplainer:

--- a/src/trustyai/explainers/explanation_results.py
+++ b/src/trustyai/explainers/explanation_results.py
@@ -29,7 +29,7 @@ class SaliencyResults(ExplanationResults):
         """Return the Saliencies as a dictionary, keyed by output name"""
 
     @abstractmethod
-    def _matplotlib_plot(self, output_name: str, block: bool) -> None:
+    def _matplotlib_plot(self, output_name: str, block: bool, call_show: bool) -> None:
         """Plot the saliencies of a particular output in matplotlib"""
 
     @abstractmethod
@@ -44,7 +44,9 @@ class SaliencyResults(ExplanationResults):
             for output_name in self.saliency_map().keys()
         }
 
-    def plot(self, output_name=None, render_bokeh=False, block=True) -> None:
+    def plot(
+        self, output_name=None, render_bokeh=False, block=True, call_show=True
+    ) -> None:
         """
         Plot the found feature saliencies.
 
@@ -57,15 +59,19 @@ class SaliencyResults(ExplanationResults):
             (default= `False`) If true, render plot in bokeh, otherwise use matplotlib.
         block: bool
             (default= `True`) Whether displaying the plot blocks subsequent code execution
+        call_show: bool
+            (default= 'True') Whether plt.show() will be called by default at the end of the
+            plotting function. If `False`, the plot will be returned to the user for further
+            editing.
         """
         if output_name is None:
             for output_name_iterator in self.saliency_map().keys():
                 if render_bokeh:
                     show(self._get_bokeh_plot(output_name_iterator))
                 else:
-                    self._matplotlib_plot(output_name_iterator, block)
+                    self._matplotlib_plot(output_name_iterator, block, call_show)
         else:
             if render_bokeh:
                 show(self._get_bokeh_plot(output_name))
             else:
-                self._matplotlib_plot(output_name, block)
+                self._matplotlib_plot(output_name, block, call_show)

--- a/src/trustyai/explainers/lime.py
+++ b/src/trustyai/explainers/lime.py
@@ -137,7 +137,7 @@ class LimeResults(SaliencyResults):
             )
         return htmls
 
-    def _matplotlib_plot(self, output_name: str, block=True) -> None:
+    def _matplotlib_plot(self, output_name: str, block=True, call_show=True) -> None:
         """Plot the LIME saliencies."""
         with mpl.rc_context(drcp):
             dictionary = {}
@@ -163,7 +163,9 @@ class LimeResults(SaliencyResults):
             )
             plt.yticks(range(len(dictionary)), list(dictionary.keys()))
             plt.tight_layout()
-            plt.show(block=block)
+
+            if call_show:
+                plt.show(block=block)
 
     def _get_bokeh_plot(self, output_name) -> bokeh.models.Plot:
         lime_data_source = pd.DataFrame(

--- a/src/trustyai/explainers/pdp.py
+++ b/src/trustyai/explainers/pdp.py
@@ -62,7 +62,7 @@ class PDPResults(ExplanationResults):
         """
         return self.as_dataframe().style
 
-    def plot(self, output_name=None, block=True) -> None:
+    def plot(self, output_name=None, block=True, call_show=True) -> None:
         """
         Parameters
         ----------
@@ -72,6 +72,10 @@ class PDPResults(ExplanationResults):
         block: bool
             whether the plotting operation
             should be blocking or not
+        call_show: bool
+            (default= 'True') Whether plt.show() will be called by default at the end of
+            the plotting function. If `False`, the plot will be returned to the user for
+            further editing.
         """
         fig, axs = plt.subplots(len(self.pdp_graphs), constrained_layout=True)
         p_idx = 0
@@ -94,7 +98,8 @@ class PDPResults(ExplanationResults):
             axs[p_idx].grid()
             p_idx += 1
         fig.supylabel("Partial Dependence Plot")
-        plt.show(block=block)
+        if call_show:
+            plt.show(block=block)
 
     @staticmethod
     def _to_plottable(datum: Value):

--- a/src/trustyai/explainers/shap.py
+++ b/src/trustyai/explainers/shap.py
@@ -201,7 +201,7 @@ class SHAPResults(SaliencyResults):
             )
         return df_dict
 
-    def _matplotlib_plot(self, output_name, block=True) -> None:
+    def _matplotlib_plot(self, output_name, block=True, call_show=True) -> None:
         """Visualize the SHAP explanation of each output as a set of candlestick plots,
         one per output."""
         with mpl.rc_context(drcp):
@@ -219,7 +219,9 @@ class SHAPResults(SaliencyResults):
             ]
             fnull = self.get_fnull()[output_name]
             prediction = fnull + sum(shap_values)
-            plt.figure()
+
+            if call_show:
+                plt.figure()
             pos = fnull
             for j, shap_value in enumerate(shap_values):
                 color = (
@@ -255,7 +257,8 @@ class SHAPResults(SaliencyResults):
             plt.ylabel(self.saliency_map()[output_name].getOutput().getName())
             plt.xlabel("Feature SHAP Value")
             plt.title(f"SHAP: Feature Contributions to {output_name}")
-            plt.show(block=block)
+            if call_show:
+                plt.show(block=block)
 
     def _get_bokeh_plot(self, output_name):
         fnull = self.get_fnull()[output_name]

--- a/tests/general/test_shap.py
+++ b/tests/general/test_shap.py
@@ -5,6 +5,7 @@ from common import *
 
 import pandas as pd
 import numpy as np
+import matplotlib.pyplot as plt
 
 np.random.seed(0)
 
@@ -133,3 +134,25 @@ def test_shap_numpy():
         assert oname in explanation.as_dataframe().keys()
         for fname in fnames:
             assert fname in explanation.as_dataframe()[oname]['Feature'].values
+
+
+# deliberately make strange plot to test pre and post-function plot editing
+def test_shap_edit_plot():
+    np.random.seed(0)
+    data = pd.DataFrame(np.random.rand(101, 5))
+    background = data.iloc[:100].values
+    to_explain = data.iloc[100:101].values
+
+    model_weights = np.random.rand(5)
+    predict_function = lambda x: np.stack([np.dot(x, model_weights), 2 * np.dot(x, model_weights)], -1)
+
+    model = Model(predict_function, disable_arrow=True)
+
+    shap_explainer = SHAPExplainer(background=background)
+    explanation = shap_explainer.explain(inputs=to_explain, outputs=model(to_explain), model=model)
+
+    plt.figure(figsize=(32,2))
+    explanation.plot(call_show=False)
+    plt.ylim(0, 123)
+    plt.show()
+


### PR DESCRIPTION
This adds a `call_show` flag to the `.plot()` function of explanation results, which can be set to `False` for manual creation+editing of subplots, figures, axes, etc.