### PR TITLE
fix: Fixed broken gridding after bokeh 3.0.x update

### DIFF
--- a/src/trustyai/utils/tyrus.py
+++ b/src/trustyai/utils/tyrus.py
@@ -285,7 +285,7 @@ class Tyrus:
                 title="Available Counterfactuals",
                 tools=["crosshair"],
                 tooltips="@{{Tooltip {}}}".format(output_name),
-                sizing_mode='stretch_both'
+                sizing_mode="stretch_both",
             )
             plot.xgrid.grid_line_color = None
             plot.xaxis.axis_label = "Counterfactual House Value"
@@ -330,12 +330,12 @@ class Tyrus:
                     TabPanel(
                         child=Div(
                             text=LIME_TEXT.format(output_html(title)),
-                            styles={'overflow-y':'scroll'}
+                            styles={"overflow-y": "scroll"},
                         ),
                         title="About LIME",
                     ),
                 ],
-                sizing_mode='stretch_both',
+                sizing_mode="stretch_both",
             )
             shap_tabbed = Tabs(
                 tabs=[
@@ -343,12 +343,12 @@ class Tyrus:
                     TabPanel(
                         child=Div(
                             text=SHAP_TEXT.format(output_html(title)),
-                            styles={'overflow-y': 'scroll'}
+                            styles={"overflow-y": "scroll"},
                         ),
                         title="About SHAP",
                     ),
                 ],
-                sizing_mode='stretch_both'
+                sizing_mode="stretch_both",
             )
 
             cf_tabbed = Tabs(
@@ -361,7 +361,7 @@ class Tyrus:
                         title="About Counterfactuals",
                     ),
                 ],
-                sizing_mode='stretch_both'
+                sizing_mode="stretch_both",
             )
 
             # trustyai_content = row(column(lime_tabbed, shap_tabbed), cf_tabbed)
@@ -372,7 +372,7 @@ class Tyrus:
                     (shap_tabbed, 1, 0, 1, 1),
                     (cf_tabbed, 0, 1, 2, 2),
                 ],
-                sizing_mode='stretch_width'
+                sizing_mode="stretch_width",
             )
             joint = column(
                 Div(

--- a/src/trustyai/utils/tyrus.py
+++ b/src/trustyai/utils/tyrus.py
@@ -8,7 +8,7 @@ import tempfile
 import numpy as np
 import pandas as pd
 from bokeh.io import show, output_file, output_notebook, reset_output
-from bokeh.layouts import column
+from bokeh.layouts import row, column, grid
 from bokeh.models import (
     ColumnDataSource,
     LinearColorMapper,
@@ -282,10 +282,10 @@ class Tyrus:
             ][0]
             source = ColumnDataSource(self.cf_data_source)
             plot = figure(
-                sizing_mode="stretch_both",
                 title="Available Counterfactuals",
                 tools=["crosshair"],
                 tooltips="@{{Tooltip {}}}".format(output_name),
+                sizing_mode='stretch_both'
             )
             plot.xgrid.grid_line_color = None
             plot.xaxis.axis_label = "Counterfactual House Value"
@@ -328,19 +328,27 @@ class Tyrus:
                 tabs=[
                     TabPanel(child=lime_figures[k], title="LIME"),
                     TabPanel(
-                        child=Div(text=LIME_TEXT.format(output_html(title))),
+                        child=Div(
+                            text=LIME_TEXT.format(output_html(title)),
+                            styles={'overflow-y':'scroll'}
+                        ),
                         title="About LIME",
                     ),
-                ]
+                ],
+                sizing_mode='stretch_both',
             )
             shap_tabbed = Tabs(
                 tabs=[
                     TabPanel(child=shap_figures[k], title="SHAP"),
                     TabPanel(
-                        child=Div(text=SHAP_TEXT.format(output_html(title))),
+                        child=Div(
+                            text=SHAP_TEXT.format(output_html(title)),
+                            styles={'overflow-y': 'scroll'}
+                        ),
                         title="About SHAP",
                     ),
-                ]
+                ],
+                sizing_mode='stretch_both'
             )
 
             cf_tabbed = Tabs(
@@ -352,15 +360,19 @@ class Tyrus:
                         ),
                         title="About Counterfactuals",
                     ),
-                ]
+                ],
+                sizing_mode='stretch_both'
             )
+
+            # trustyai_content = row(column(lime_tabbed, shap_tabbed), cf_tabbed)
 
             trustyai_content = GridBox(
                 children=[
                     (lime_tabbed, 0, 0, 1, 1),
                     (shap_tabbed, 1, 0, 1, 1),
                     (cf_tabbed, 0, 1, 2, 2),
-                ]
+                ],
+                sizing_mode='stretch_width'
             )
             joint = column(
                 Div(
@@ -369,11 +381,10 @@ class Tyrus:
                     )
                 ),
                 trustyai_content,
-                sizing_mode="scale_width",
             )
             tabs.append(TabPanel(child=joint, title=title))
 
-        full_dash = Tabs(tabs=tabs, sizing_mode="scale_width")
+        full_dash = Tabs(tabs=tabs, sizing_mode="scale_both")
         return full_dash
 
     def run(self, display=True):

--- a/src/trustyai/utils/tyrus.py
+++ b/src/trustyai/utils/tyrus.py
@@ -8,7 +8,7 @@ import tempfile
 import numpy as np
 import pandas as pd
 from bokeh.io import show, output_file, output_notebook, reset_output
-from bokeh.layouts import row, column, grid
+from bokeh.layouts import column
 from bokeh.models import (
     ColumnDataSource,
     LinearColorMapper,


### PR DESCRIPTION
Bokeh 3.0.x upgrade changed how bokeh's gridding and dynamic resizing works, this PR fixes the gridding+dynamic resizing functionality to (somewhat) return to how Tyrus was intended to look