### PR TITLE
Update direct dependency to released dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
     "xgboost==1.4.2"
 ]
 extras = [
-    "aix360 [default,tsice,tslime,tssaliency] @ https://github.com/Trusted-AI/AIX360/archive/refs/heads/master.zip"
+    "aix360[default,tsice,tslime,tssaliency]==0.3.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
AIX360 0.3.0 is now released. This replaces the direct dependency with a PyPi dependency so that Python TrustyAI can be released.